### PR TITLE
Alterações no back-end LAPA

### DIFF
--- a/back/src/main/java/br/edu/ufape/hvu/controller/dto/request/FichaSolicitacaoServicoRequest.java
+++ b/back/src/main/java/br/edu/ufape/hvu/controller/dto/request/FichaSolicitacaoServicoRequest.java
@@ -14,8 +14,6 @@ import lombok.Setter;
 
 @Getter @Setter @NoArgsConstructor 
 public  class FichaSolicitacaoServicoRequest  {
-	private boolean criarLaudoNecropsia; //indica se deve criar o laudo de necropsia
-	private boolean criarLaudoMicroscopia; //indica se deve criar o laudo de microscopia
 	private Date dataHoraObito;
 	private EstadoConservacao estadoConservacao;
 	private String historico;

--- a/back/src/main/java/br/edu/ufape/hvu/controller/dto/request/LaudoNecropsiaRequest.java
+++ b/back/src/main/java/br/edu/ufape/hvu/controller/dto/request/LaudoNecropsiaRequest.java
@@ -19,8 +19,7 @@ public  class LaudoNecropsiaRequest  {
 	private Microscopia tipoMicroscopia;
 	private String conclusao;
 	private FichaSolicitacaoServicoRequest fichaSolicitacaoServico; 
-	private CampoLaudoRequest campoLaudo; 
-	private LaudoMicroscopiaRequest laudoMicroscopia; 
+	private CampoLaudoRequest campoLaudo;
 	private FotoRequest foto; 
 	private List<EstagiarioRequest> estagiario;
 	private long id;

--- a/back/src/main/java/br/edu/ufape/hvu/controller/dto/response/FichaSolicitacaoServicoResponse.java
+++ b/back/src/main/java/br/edu/ufape/hvu/controller/dto/response/FichaSolicitacaoServicoResponse.java
@@ -2,8 +2,6 @@ package br.edu.ufape.hvu.controller.dto.response;
 
 import java.util.Date;
 
-import br.edu.ufape.hvu.model.LaudoMicroscopia;
-import br.edu.ufape.hvu.model.LaudoNecropsia;
 import org.modelmapper.ModelMapper;
 
 import br.edu.ufape.hvu.config.SpringApplicationContext;
@@ -20,8 +18,6 @@ import lombok.Setter;
 @Getter @Setter @NoArgsConstructor
 public  class FichaSolicitacaoServicoResponse  {
 	private Long id;
-	private boolean criarLaudoNecropsia; //indica se deve criar o laudo de necropsia
-	private boolean criarLaudoMicroscopia; //indica se deve criar o laudo de microscopia
 	private Date dataHoraObito;
 	private EstadoConservacao estadoConservacao;
 	private String historico;
@@ -29,9 +25,6 @@ public  class FichaSolicitacaoServicoResponse  {
 	private TutorResponse tutor;
 	private AnimalResponse animal; 
 	private MedicoResponse medico;
-	private LaudoMicroscopia laudoMicroscopia;
-	private LaudoNecropsia laudoNecropsia;
-
 
 	public FichaSolicitacaoServicoResponse(FichaSolicitacaoServico obj) {
 		ModelMapper modelMapper = (ModelMapper) SpringApplicationContext.getBean("modelMapper");

--- a/back/src/main/java/br/edu/ufape/hvu/controller/dto/response/LaudoMicroscopiaResponse.java
+++ b/back/src/main/java/br/edu/ufape/hvu/controller/dto/response/LaudoMicroscopiaResponse.java
@@ -16,7 +16,6 @@ import lombok.Setter;
 public  class LaudoMicroscopiaResponse  {
 	private Long id;
 	private String conclusao;
-	private FichaSolicitacaoServicoResponse fichaSolicitacaoServico; 
 	private CampoLaudoResponse campoLaudo; 
 	private EtapaResponse etapa; 
 	private List<EstagiarioResponse> estagiario; 

--- a/back/src/main/java/br/edu/ufape/hvu/facade/Facade.java
+++ b/back/src/main/java/br/edu/ufape/hvu/facade/Facade.java
@@ -1366,20 +1366,6 @@ public class Facade {
 	FichaSolicitacaoServicoServiceInterface fichaSolicitacaoServicoServiceInterface;
 
 	public FichaSolicitacaoServico saveFichaSolicitacaoServico(FichaSolicitacaoServico newInstance) {
-		if(newInstance.isCriarLaudoNecropsia()){
-			LaudoNecropsia laudoNecropsia = new LaudoNecropsia();
-			laudoNecropsiaServiceInterfcae.saveLaudoNecropsia(laudoNecropsia);
-			newInstance.setLaudoNecropsia(laudoNecropsia);
-		} else {
-			newInstance.setLaudoNecropsia(null);
-		}
-		if(newInstance.isCriarLaudoMicroscopia()){
-			LaudoMicroscopia laudoMicroscopia = new LaudoMicroscopia();
-			laudoMicroscopiaServiceInterface.saveLaudoMicroscopia(laudoMicroscopia);
-			newInstance.setLaudoMicroscopia(laudoMicroscopia);
-		} else {
-			newInstance.setLaudoMicroscopia(null);
-		}
 		return fichaSolicitacaoServicoServiceInterface.saveFichaSolicitacaoServico(newInstance);
 	}
 

--- a/back/src/main/java/br/edu/ufape/hvu/model/FichaSolicitacaoServico.java
+++ b/back/src/main/java/br/edu/ufape/hvu/model/FichaSolicitacaoServico.java
@@ -1,9 +1,7 @@
 package br.edu.ufape.hvu.model;
 
 import java.util.Date;
-
 import br.edu.ufape.hvu.model.enums.EstadoConservacao;
-import br.edu.ufape.hvu.repository.FichaSolicitacaoServicoRepository;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -11,7 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -26,14 +23,13 @@ public class FichaSolicitacaoServico {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @EqualsAndHashCode.Include
     private long id;
-    private boolean criarLaudoNecropsia; //indica se deve criar o laudo de necropsia
-    private boolean criarLaudoMicroscopia; //indica se deve criar o laudo de microscopia
     private Date dataHoraObito;
     private EstadoConservacao estadoConservacao;
     private String historico;
     private String caracteristicasAdicionais;
     @OneToOne
     @ToString.Exclude
+    @JoinColumn(name = "animal_id)")
     private Animal animal;
     @OneToOne
     @ToString.Exclude
@@ -42,12 +38,4 @@ public class FichaSolicitacaoServico {
     @JoinColumn(name = "medico_id")
     @ToString.Exclude
     private Medico medico;
-    @OneToOne
-    @JoinColumn(name = "laudoNecropsia_id")
-    @ToString.Exclude
-    private LaudoNecropsia laudoNecropsia;
-    @OneToOne
-    @JoinColumn(name = "laudoMicroscopia_id")
-    @ToString.Exclude
-    private LaudoMicroscopia laudoMicroscopia;
 }

--- a/back/src/main/java/br/edu/ufape/hvu/model/LaudoNecropsia.java
+++ b/back/src/main/java/br/edu/ufape/hvu/model/LaudoNecropsia.java
@@ -3,17 +3,7 @@ package br.edu.ufape.hvu.model;
 import java.util.List;
 
 import br.edu.ufape.hvu.model.enums.Microscopia;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Inheritance;
-import jakarta.persistence.InheritanceType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -46,10 +36,10 @@ public class LaudoNecropsia {
     @JoinColumn(name = "campoLaudo_id")
     @ToString.Exclude
     private CampoLaudo campoLaudo;
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "foto_id")
     @ToString.Exclude
-    private Foto foto;
+    private List<Foto> foto;
     @ManyToMany
     @ToString.Exclude
     private List<Estagiario> estagiario;


### PR DESCRIPTION
> Remoção do método de criar os laudos a partir da escolha na ficha de solicitação de serviço. (Os laudos agora são criados independentemente e puxam as informações da Ficha de solicitação de serviço)

Essa alteração corrige o problema da lista de vários laudos de miscroscopia.