### PR TITLE
Substituir vínculo de Ficha com Consulta por Agendamento

### DIFF
--- a/back/src/main/java/br/edu/ufape/hvu/controller/FichaController.java
+++ b/back/src/main/java/br/edu/ufape/hvu/controller/FichaController.java
@@ -1,8 +1,8 @@
 package br.edu.ufape.hvu.controller;
 
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
 import br.edu.ufape.hvu.facade.Facade;
@@ -15,7 +15,7 @@ import br.edu.ufape.hvu.controller.dto.response.FichaResponse;
 public class FichaController {
     private final Facade facade;
 
-   // @PreAuthorize("hasAnyRole('SECRETARIO','MEDICO')")
+    @PreAuthorize("hasAnyRole('SECRETARIO','MEDICO')")
     @GetMapping("ficha")
     public List<FichaResponse> getAllFicha() {
         return facade.getAllFicha()
@@ -24,19 +24,20 @@ public class FichaController {
                 .toList();
     }
 
-  //  @PreAuthorize("hasAnyRole('SECRETARIO','MEDICO')")
+    @PreAuthorize("hasAnyRole('SECRETARIO','MEDICO')")
     @PostMapping("ficha")
     public FichaResponse createFicha(@Valid @RequestBody FichaRequest newObj) {
         return new FichaResponse(facade.saveFicha(newObj.convertToEntity()));
     }
 
- //   @PreAuthorize("hasAnyRole('TUTOR','SECRETARIO','MEDICO' )")
+    @PreAuthorize("hasAnyRole('SECRETARIO','MEDICO')")
     @GetMapping("ficha/{id}")
     public FichaResponse getFichaById(@PathVariable Long id) {
         return new FichaResponse(facade.findFichaById(id));
     }
 
-    @GetMapping("/ficha/animal/{animalId}")
+    @PreAuthorize("hasAnyRole('SECRETARIO','MEDICO')")
+    @GetMapping("ficha/animal/{animalId}")
     public List<FichaResponse> findFichasByAnimalId(@PathVariable Long animalId) {
         return facade.findFichasByAnimalId(animalId)
                 .stream()
@@ -44,13 +45,22 @@ public class FichaController {
                 .toList();
     }
 
-    //@PreAuthorize("hasAnyRole('SECRETARIO','MEDICO')")
+    @PreAuthorize("hasAnyRole('SECRETARIO','MEDICO')")
+    @GetMapping("ficha/agendamento/{agendamentoId}")
+    public List<FichaResponse> findFichasByAgendamentoId(@PathVariable Long agendamentoId) {
+        return facade.findFichasByAgendamentoId(agendamentoId)
+                .stream()
+                .map(FichaResponse::new)
+                .toList();
+    }
+
+    @PreAuthorize("hasAnyRole('SECRETARIO','MEDICO')")
     @PatchMapping("ficha/{id}")
     public FichaResponse updateFicha(@PathVariable Long id, @Valid @RequestBody FichaRequest obj) {
         return new FichaResponse(facade.updateFicha(obj, id));
     }
 
-//    @PreAuthorize("hasAnyRole('SECRETARIO','MEDICO')")
+    @PreAuthorize("hasAnyRole('SECRETARIO','MEDICO')")
     @DeleteMapping("ficha/{id}")
     public String deleteFicha(@PathVariable Long id) {
         facade.deleteFicha(id);

--- a/back/src/main/java/br/edu/ufape/hvu/controller/dto/request/ConsultaRequest.java
+++ b/back/src/main/java/br/edu/ufape/hvu/controller/dto/request/ConsultaRequest.java
@@ -1,10 +1,6 @@
 package br.edu.ufape.hvu.controller.dto.request;
 
 import java.time.LocalDateTime;
-import java.util.List;
-
-import br.edu.ufape.hvu.controller.dto.response.EstagiarioResponse;
-import br.edu.ufape.hvu.model.enums.TipoFicha;
 import org.modelmapper.ModelMapper;
 import br.edu.ufape.hvu.config.SpringApplicationContext;
 import br.edu.ufape.hvu.model.Consulta;
@@ -12,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
-
 
 @Getter @Setter @NoArgsConstructor 
 public  class ConsultaRequest  {
@@ -24,14 +19,15 @@ public  class ConsultaRequest  {
 	private AnimalRequest animal;
 	@DateTimeFormat(pattern = "dd/MM/yyyy hh:mm")
 	private LocalDateTime dataVaga;
-	private List<FichaRequest> ficha;
 	private String queixaPrincipal;
 	private String alteracoesClinicasDiversas;
 	private String suspeitasClinicas;
 	private String alimentacao;
 	private EspecialidadeRequest encaminhamento;
+
 	public Consulta convertToEntity() {
 		ModelMapper modelMapper = (ModelMapper) SpringApplicationContext.getBean("modelMapper");
         return modelMapper.map(this, Consulta.class);
 	}
+
 }

--- a/back/src/main/java/br/edu/ufape/hvu/controller/dto/request/FichaRequest.java
+++ b/back/src/main/java/br/edu/ufape/hvu/controller/dto/request/FichaRequest.java
@@ -8,19 +8,17 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
-
 import java.time.LocalDateTime;
 import java.util.Map;
-
 
 @Getter @Setter @NoArgsConstructor
 public  class FichaRequest {
     private long id;
     private String nome;
     private Map<String, Object> conteudo;
-
     @DateTimeFormat(pattern = "dd/MM/yyyy hh:mm")
     private LocalDateTime dataHora;
+    private AgendamentoRequest agendamento;
 
     public Ficha convertToEntity() {
         Ficha ficha = new Ficha();

--- a/back/src/main/java/br/edu/ufape/hvu/controller/dto/response/ConsultaResponse.java
+++ b/back/src/main/java/br/edu/ufape/hvu/controller/dto/response/ConsultaResponse.java
@@ -1,11 +1,8 @@
 package br.edu.ufape.hvu.controller.dto.response;
 
 import java.time.LocalDateTime;
-import java.util.List;
-
 import br.edu.ufape.hvu.controller.dto.request.EspecialidadeRequest;
 import org.modelmapper.ModelMapper;
-
 import br.edu.ufape.hvu.config.SpringApplicationContext;
 import br.edu.ufape.hvu.model.Consulta;
 import lombok.Getter;
@@ -23,7 +20,6 @@ public class ConsultaResponse {
 	private AnimalResponse animal;
 	@DateTimeFormat(pattern = "dd/MM/yyyy hh:mm")
 	private LocalDateTime dataVaga;
-	private List<FichaResponse> ficha;
 	private String queixaPrincipal;
 	private String alteracoesClinicasDiversas;
 	private String suspeitasClinicas;

--- a/back/src/main/java/br/edu/ufape/hvu/controller/dto/response/FichaResponse.java
+++ b/back/src/main/java/br/edu/ufape/hvu/controller/dto/response/FichaResponse.java
@@ -16,6 +16,7 @@ public  class FichaResponse  {
     private String conteudo;
     @DateTimeFormat(pattern = "dd/MM/yyyy hh:mm")
     private LocalDateTime dataHora;
+    private AgendamentoResponse agendamento;
 
     public FichaResponse(Ficha obj) {
         ModelMapper modelMapper = (ModelMapper) SpringApplicationContext.getBean("modelMapper");

--- a/back/src/main/java/br/edu/ufape/hvu/model/Consulta.java
+++ b/back/src/main/java/br/edu/ufape/hvu/model/Consulta.java
@@ -1,9 +1,6 @@
 package br.edu.ufape.hvu.model;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -12,7 +9,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.springframework.format.annotation.DateTimeFormat;
-
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -42,6 +38,5 @@ public  class Consulta  {
 	private Animal animal;
 	@DateTimeFormat(pattern = "dd/MM/yyyy hh:mm")
 	private LocalDateTime dataVaga;
-	@OneToMany
-	private List<Ficha> ficha = new ArrayList<>();
+
 }

--- a/back/src/main/java/br/edu/ufape/hvu/model/Ficha.java
+++ b/back/src/main/java/br/edu/ufape/hvu/model/Ficha.java
@@ -1,7 +1,5 @@
 package br.edu.ufape.hvu.model;
 
-import br.edu.ufape.hvu.model.enums.TipoFicha;
-import com.fasterxml.jackson.annotation.JsonRawValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -18,7 +16,6 @@ import java.time.LocalDateTime;
 import jakarta.persistence.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
-
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Getter @Setter @NoArgsConstructor @AllArgsConstructor
@@ -34,4 +31,8 @@ public class Ficha {
     private String conteudo;
     @DateTimeFormat(pattern = "dd/MM/yyyy hh:mm")
     private LocalDateTime dataHora;
+    @ManyToOne
+    @JoinColumn(name = "agendamento_id")
+    private Agendamento agendamento;
+
 }

--- a/back/src/main/java/br/edu/ufape/hvu/repository/FichaRepository.java
+++ b/back/src/main/java/br/edu/ufape/hvu/repository/FichaRepository.java
@@ -3,8 +3,12 @@ package br.edu.ufape.hvu.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import br.edu.ufape.hvu.model.Ficha;
+import java.util.List;
 
 @Repository
 public interface FichaRepository extends JpaRepository<Ficha, Long> {
+
+    List<Ficha> findByAgendamentoId(Long agendamentoId);
+    List<Ficha> findByAgendamentoAnimalId(Long animalId);
 
 }

--- a/back/src/main/java/br/edu/ufape/hvu/repository/seeders/ConsultaSeeder.java
+++ b/back/src/main/java/br/edu/ufape/hvu/repository/seeders/ConsultaSeeder.java
@@ -5,8 +5,6 @@ import br.edu.ufape.hvu.repository.*;
 import com.github.javafaker.Faker;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-
-import java.util.Arrays;
 import java.util.List;
 
 @Component @RequiredArgsConstructor
@@ -27,10 +25,6 @@ public class ConsultaSeeder {
         consulta.setPesoAtual(faker.number().randomDouble(2, 1, 100));
         consulta.setIdadeAtual((double) faker.number().numberBetween(1, 20));
         consulta.setMedico(medicos.get(0));
-        // Criando e adicionando fichas
-        List<Ficha> fichas = fichaRepository.findAll();
-        List<Ficha> duasFichasEx = Arrays.asList(fichas.get(0),fichas.get(1));
-        consulta.setFicha(duasFichasEx);
 
         consultaRepository.save(consulta);
     }

--- a/back/src/main/java/br/edu/ufape/hvu/repository/seeders/FichaSeeder.java
+++ b/back/src/main/java/br/edu/ufape/hvu/repository/seeders/FichaSeeder.java
@@ -1,57 +1,64 @@
 package br.edu.ufape.hvu.repository.seeders;
 
+import br.edu.ufape.hvu.model.Agendamento;
 import br.edu.ufape.hvu.model.Ficha;
 import br.edu.ufape.hvu.model.enums.TipoFicha;
+import br.edu.ufape.hvu.repository.AgendamentoRepository;
 import br.edu.ufape.hvu.repository.FichaRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javafaker.Faker;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-
 import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 public class FichaSeeder {
     private final FichaRepository fichaRepository;
+    private final AgendamentoRepository agendamentoRepository;
 
     public void init(){
         if(fichaRepository.count() > 0){
             return;
         }
 
-        try{
-            for(int i = 0; i < 3; i++){
-                Ficha ficha = new Ficha();
-                Faker faker = new Faker();
-
-                TipoFicha[] tipos = TipoFicha.values();
-                TipoFicha tipoFichaAleatorio = tipos[faker.random().nextInt(tipos.length)];
-                ficha.setNome(tipoFichaAleatorio.toString());
-
-                Map<String, Object> conteudo = new HashMap<>();
-
-                conteudo.put("peso", faker.number().randomDouble(1, 50, 100));
-                conteudo.put("queixa_principal", faker.lorem().sentence());
-                conteudo.put("historico_medico_previo", faker.lorem().sentence());
-
-                ObjectMapper mapper = new ObjectMapper();
-                String conteudoJson = mapper.writeValueAsString(conteudo);
-                ficha.setConteudo(conteudoJson);
-                ficha.setDataHora(LocalDateTime.parse("2025-04-08T10:00:00"));
-                fichaRepository.save(ficha);
-            }
-        } catch (RuntimeException | JsonProcessingException e) {
-            throw new RuntimeException(e);
+        List<Agendamento> agendamentos = agendamentoRepository.findAll();
+        if (agendamentos.isEmpty()) {
+            throw new RuntimeException("Nenhum agendamento disponível para vincular às fichas.");
         }
 
+        Faker faker = new Faker();
+        TipoFicha[] tipos = TipoFicha.values();
+        ObjectMapper mapper = new ObjectMapper();
 
+        for (int i = 0; i < 3; i++) {
+            Ficha ficha = new Ficha();
+
+            TipoFicha tipoFichaAleatorio = tipos[faker.random().nextInt(tipos.length)];
+            ficha.setNome(tipoFichaAleatorio.toString());
+
+            Map<String, Object> conteudo = new HashMap<>();
+            conteudo.put("peso", faker.number().randomDouble(1, 50, 100));
+            conteudo.put("queixa_principal", faker.lorem().sentence());
+            conteudo.put("historico_medico_previo", faker.lorem().sentence());
+
+            try {
+                String conteudoJson = mapper.writeValueAsString(conteudo);
+                ficha.setConteudo(conteudoJson);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Erro ao criar JSON de conteúdo da ficha", e);
+            }
+
+            ficha.setDataHora(LocalDateTime.parse("2025-04-08T10:00:00"));
+            Agendamento agendamentoAleatorio = agendamentos.get(faker.random().nextInt(agendamentos.size()));
+            ficha.setAgendamento(agendamentoAleatorio);
+
+            fichaRepository.save(ficha);
+        }
     }
-
-
-
 
 }

--- a/back/src/main/java/br/edu/ufape/hvu/service/FichaService.java
+++ b/back/src/main/java/br/edu/ufape/hvu/service/FichaService.java
@@ -28,6 +28,14 @@ public class FichaService implements FichaServiceInterface {
         return repository.findById(id).orElseThrow( () -> new IdNotFoundException(id, "Ficha"));
     }
 
+    public List<Ficha> findFichasByAgendamentoId(long agendamentoId) {
+        return repository.findByAgendamentoId(agendamentoId);
+    }
+
+    public List<Ficha> findFichasByAnimalId(long animalId) {
+        return repository.findByAgendamentoAnimalId(animalId);
+    }
+
     public List<Ficha> getAllFicha(){
         return repository.findAll();
     }

--- a/back/src/main/java/br/edu/ufape/hvu/service/FichaServiceInterface.java
+++ b/back/src/main/java/br/edu/ufape/hvu/service/FichaServiceInterface.java
@@ -7,6 +7,8 @@ import java.util.List;
 public interface FichaServiceInterface {
     Ficha saveFicha(Ficha o);
     Ficha findFichaById(long id);
+    List<Ficha> findFichasByAgendamentoId(long agendamentoId);
+    List<Ficha> findFichasByAnimalId(long animalId);
     Ficha updateFicha(Ficha u);
     void deleteFicha(long id);
     List<Ficha> getAllFicha();


### PR DESCRIPTION
- Ficha agora está vinculada diretamente a Agendamento.
- Removido o relacionamento com Consulta.
- Atualizados DTOs, controladores, serviços, repositório e seeders.
- Alteração quebra compatibilidade: fichas não usam mais consulta.

Closes #794