### PR TITLE
implementar geração automática de código de prontuário

### DIFF
--- a/back/src/main/java/br/edu/ufape/hvu/controller/AnimalController.java
+++ b/back/src/main/java/br/edu/ufape/hvu/controller/AnimalController.java
@@ -2,6 +2,8 @@ package br.edu.ufape.hvu.controller;
 
 import java.util.List;
 import br.edu.ufape.hvu.controller.dto.request.AnimalByPatologistaRequest;
+import br.edu.ufape.hvu.controller.dto.request.ValorInicialProntuarioRequest;
+import br.edu.ufape.hvu.controller.dto.response.ContadorProntuarioResponse;
 import br.edu.ufape.hvu.model.enums.OrigemAnimal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -132,4 +134,12 @@ public class AnimalController {
         Jwt principal = (Jwt) authentication.getPrincipal();
         return facade.findAnimalsByOrigemAnimal(origem, principal.getSubject());
     }
+
+	@PreAuthorize("hasRole('SECRETARIO')")
+	@PostMapping("animal/prontuario/valor-inicial")
+	public ContadorProntuarioResponse definirValorInicialProntuario(
+			@Valid @RequestBody ValorInicialProntuarioRequest request
+	) {
+		return facade.definirValorInicialProntuario(request);
+	}
 }

--- a/back/src/main/java/br/edu/ufape/hvu/controller/dto/request/AnimalRequest.java
+++ b/back/src/main/java/br/edu/ufape/hvu/controller/dto/request/AnimalRequest.java
@@ -2,6 +2,7 @@ package br.edu.ufape.hvu.controller.dto.request;
 
 import java.time.LocalDate;
 import br.edu.ufape.hvu.model.enums.OrigemAnimal;
+import br.edu.ufape.hvu.model.enums.TipoAnimal;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.modelmapper.ModelMapper;
@@ -11,7 +12,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter @Setter @NoArgsConstructor 
+@Getter
+@Setter
+@NoArgsConstructor
 public class AnimalRequest {
     private long id;
 	@NotBlank(message = "Nome não pode estar em branco")
@@ -31,6 +34,7 @@ public class AnimalRequest {
 	private String numeroFicha;
 	private OrigemAnimal origemAnimal;
 	private boolean obito;
+	private TipoAnimal tipo;
 
 	public Animal convertToEntity() {
 		ModelMapper modelMapper = (ModelMapper) SpringApplicationContext.getBean("modelMapper");

--- a/back/src/main/java/br/edu/ufape/hvu/controller/dto/request/FichaRequest.java
+++ b/back/src/main/java/br/edu/ufape/hvu/controller/dto/request/FichaRequest.java
@@ -25,7 +25,11 @@ public class FichaRequest {
     @DateTimeFormat(pattern = "dd/MM/yyyy hh:mm")
     private LocalDateTime dataHora;
 
+    // nao é obrigatorio
     private AgendamentoRequest agendamento;
+
+    @NotNull(message = "O id do animal é obrigatório.")
+    private AnimalRequest animal;
 
     public Ficha convertToEntity() {
         Ficha ficha = new Ficha();
@@ -43,6 +47,7 @@ public class FichaRequest {
         if (this.agendamento != null) {
             ficha.setAgendamento(this.agendamento.convertToEntity());
         }
+        ficha.setAnimal(this.animal.convertToEntity());
 
         return ficha;
     }
@@ -62,5 +67,6 @@ public class FichaRequest {
         if (this.agendamento != null) {
             ficha.setAgendamento(this.agendamento.convertToEntity());
         }
+        ficha.setAnimal(this.animal.convertToEntity());
     }
 }

--- a/back/src/main/java/br/edu/ufape/hvu/controller/dto/request/ValorInicialProntuarioRequest.java
+++ b/back/src/main/java/br/edu/ufape/hvu/controller/dto/request/ValorInicialProntuarioRequest.java
@@ -1,0 +1,11 @@
+package br.edu.ufape.hvu.controller.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record ValorInicialProntuarioRequest(
+
+        @NotNull(message = "Valor inicial não pode estar em branco")
+        @Min(value = 1, message = "Valor inicial deve ser maior ou igual a 1")
+        Integer valorInicial
+) {}

--- a/back/src/main/java/br/edu/ufape/hvu/controller/dto/response/AnimalResponse.java
+++ b/back/src/main/java/br/edu/ufape/hvu/controller/dto/response/AnimalResponse.java
@@ -1,20 +1,19 @@
 package br.edu.ufape.hvu.controller.dto.response;
 
 import java.time.LocalDate;
-
 import br.edu.ufape.hvu.model.enums.OrigemAnimal;
+import br.edu.ufape.hvu.model.enums.TipoAnimal;
 import org.modelmapper.ModelMapper;
-
 import br.edu.ufape.hvu.config.SpringApplicationContext;
 import br.edu.ufape.hvu.model.Animal;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-
-
-@Getter @Setter @NoArgsConstructor
-public  class AnimalResponse  {
+@Getter
+@Setter
+@NoArgsConstructor
+public class AnimalResponse {
 	private long id;
 	private String nome;
 	private String sexo;
@@ -27,11 +26,11 @@ public  class AnimalResponse  {
 	private RacaResponse raca;
 	private OrigemAnimal origemAnimal;
 	private boolean obito;
-
+	private String codigoProntuario;
+	private TipoAnimal tipo;
 
 	public AnimalResponse(Animal obj) {
 		ModelMapper modelMapper = (ModelMapper) SpringApplicationContext.getBean("modelMapper");
 		modelMapper.map(obj, this);	
 	}
-
 }

--- a/back/src/main/java/br/edu/ufape/hvu/controller/dto/response/ContadorProntuarioResponse.java
+++ b/back/src/main/java/br/edu/ufape/hvu/controller/dto/response/ContadorProntuarioResponse.java
@@ -1,0 +1,15 @@
+package br.edu.ufape.hvu.controller.dto.response;
+
+import br.edu.ufape.hvu.model.ContadorProntuario;
+
+public record ContadorProntuarioResponse(
+        int ultimoValor,
+        boolean valorInicialConfigurado
+) {
+    public ContadorProntuarioResponse(ContadorProntuario contador) {
+        this(
+                contador.getUltimoValor(),
+                contador.isValorInicialConfigurado()
+        );
+    }
+}

--- a/back/src/main/java/br/edu/ufape/hvu/controller/dto/response/FichaResponse.java
+++ b/back/src/main/java/br/edu/ufape/hvu/controller/dto/response/FichaResponse.java
@@ -18,6 +18,7 @@ public  class FichaResponse  {
     private LocalDateTime dataHora;
     private AgendamentoResponse agendamento;
     private MedicoResponse medico;
+    private AnimalResponse animal;
 
     public FichaResponse(Ficha obj) {
         ModelMapper modelMapper = (ModelMapper) SpringApplicationContext.getBean("modelMapper");

--- a/back/src/main/java/br/edu/ufape/hvu/facade/Facade.java
+++ b/back/src/main/java/br/edu/ufape/hvu/facade/Facade.java
@@ -1112,10 +1112,6 @@ public class Facade {
             throw new IllegalArgumentException("A vaga não pode estar no passado.");
         }
 
-        // Só gera códigos de prontuário para animais que nunca tiveram agendamento
-        if (!agendamentoRepository.existsByAnimalId(animal.getId())) {
-            codigoProntuarioService.garantirCodigoProntuario(animal.getId());
-        }
         Agendamento agendamento = newInstance.convertToEntity();
         agendamento.setAnimal(animal);
         return confirmarAgendamento(vaga, agendamento);
@@ -1146,10 +1142,6 @@ public class Facade {
 
         saveVaga(vaga);
 
-        // Só gera códigos de prontuário para animais que nunca tiveram agendamento
-        if (!agendamentoRepository.existsByAnimalId(animal.getId())) {
-            codigoProntuarioService.garantirCodigoProntuario(animal.getId());
-        }
         agendamento.setAnimal(findAnimalById(newObject.getAnimal().getId(), idSession));
         agendamento.setTipoEspecial(newObject.isTipoEspecial());
 
@@ -1769,6 +1761,11 @@ public class Facade {
 
         Medico medico = medicoServiceInterface.findByUserId(sessionId);
         newInstance.setMedico(medico);
+
+        // Só gera códigos de prontuário para animais que nunca tiveram ficha
+        if (!fichaServiceInterface.existsByAnimalId(newInstance.getAnimal().getId())) {
+            codigoProntuarioService.garantirCodigoProntuario(newInstance.getAnimal().getId());
+        }
 
         return fichaServiceInterface.saveFicha(newInstance);
     }

--- a/back/src/main/java/br/edu/ufape/hvu/facade/Facade.java
+++ b/back/src/main/java/br/edu/ufape/hvu/facade/Facade.java
@@ -10,11 +10,13 @@ import java.util.*;
 import java.util.stream.Collectors;
 import br.edu.ufape.hvu.controller.dto.auth.TokenResponse;
 import br.edu.ufape.hvu.controller.dto.request.*;
+import br.edu.ufape.hvu.controller.dto.response.ContadorProntuarioResponse;
 import br.edu.ufape.hvu.controller.dto.response.TutorEAnimalPorOrigemFlatResponse;
 import br.edu.ufape.hvu.exception.OrigemAnimalInvalidaException;
 import br.edu.ufape.hvu.exception.ResourceNotFoundException;
 import br.edu.ufape.hvu.exception.types.BusinessException;
 import br.edu.ufape.hvu.exception.types.auth.ForbiddenOperationException;
+import br.edu.ufape.hvu.model.enums.TipoAnimal;
 import br.edu.ufape.hvu.model.enums.TipoServico;
 import br.edu.ufape.hvu.repository.AgendamentoRepository;
 import br.edu.ufape.hvu.model.enums.OrigemAnimal;
@@ -1110,6 +1112,10 @@ public class Facade {
             throw new IllegalArgumentException("A vaga não pode estar no passado.");
         }
 
+        // Só gera códigos de prontuário para animais que nunca tiveram agendamento
+        if (!agendamentoRepository.existsByAnimalId(animal.getId())) {
+            codigoProntuarioService.garantirCodigoProntuario(animal.getId());
+        }
         Agendamento agendamento = newInstance.convertToEntity();
         agendamento.setAnimal(animal);
         return confirmarAgendamento(vaga, agendamento);
@@ -1140,6 +1146,10 @@ public class Facade {
 
         saveVaga(vaga);
 
+        // Só gera códigos de prontuário para animais que nunca tiveram agendamento
+        if (!agendamentoRepository.existsByAnimalId(animal.getId())) {
+            codigoProntuarioService.garantirCodigoProntuario(animal.getId());
+        }
         agendamento.setAnimal(findAnimalById(newObject.getAnimal().getId(), idSession));
         agendamento.setTipoEspecial(newObject.isTipoEspecial());
 
@@ -1388,6 +1398,7 @@ public class Facade {
 
     // Animal--------------------------------------------------------------
     private final AnimalServiceInterface animalServiceInterface;
+    private final CodigoProntuarioService codigoProntuarioService;
 
     private void validarOrigemAnimal(String role, OrigemAnimal origemAnimal) {
         if ("TUTOR".equals(role) && origemAnimal != OrigemAnimal.HVU) {
@@ -1410,10 +1421,13 @@ public class Facade {
             throw new ResourceNotFoundException("Tutor", "o idSession ", idSession);
         }
 
+        if (newInstance.getTipo() == null) {
+            newInstance.setTipo(TipoAnimal.COMUM);
+        }
+
         if (newInstance.getOrigemAnimal() == null) {
             newInstance.setOrigemAnimal(OrigemAnimal.HVU);
         }
-
         validarOrigemAnimal("TUTOR", newInstance.getOrigemAnimal());
 
         if (tutor.getAnimais() == null) {
@@ -1448,9 +1462,22 @@ public class Facade {
         return tutorServiceInterface.saveTutor(request.getTutor().convertToEntity());
     }
 
+    public ContadorProntuarioResponse definirValorInicialProntuario(
+            ValorInicialProntuarioRequest request) {
+
+        ContadorProntuario contador =
+                codigoProntuarioService.definirValorInicial(request.valorInicial());
+
+        return new ContadorProntuarioResponse(contador);
+    }
+
     @Transactional
     public Animal saveAnimalByPatologista(AnimalByPatologistaRequest request) {
         Animal animal = request.getAnimal().convertToEntity();
+
+        if (animal.getTipo() == null) {
+            animal.setTipo(TipoAnimal.COMUM);
+        }
 
         if (animal.getOrigemAnimal() == null) {
             animal.setOrigemAnimal(OrigemAnimal.LAPA);
@@ -1725,17 +1752,19 @@ public class Facade {
 
     // Ficha--------------------------------------------------------------
 
-
     private final FichaServiceInterface fichaServiceInterface;
 
     @Transactional
     public Ficha saveFicha(Ficha newInstance, String sessionId) {
-        if (newInstance.getAgendamento() == null || newInstance.getAgendamento().getId() <= 0) {
-            throw new IllegalArgumentException("Ficha deve estar vinculada a um agendamento válido.");
+        if (newInstance.getAnimal() == null || newInstance.getAnimal().getId() <= 0) {
+            throw new IllegalArgumentException("Ficha deve estar vinculada a um animal válido.");
         }
 
-        if (!agendamentoRepository.existsById(newInstance.getAgendamento().getId())) {
-            throw new ResourceNotFoundException("Agendamento", "id", newInstance.getAgendamento().getId());
+        if (!animalRepository.existsById(newInstance.getAnimal().getId())) {
+            throw new ResourceNotFoundException(
+                    "Animal",
+                    "id",
+                    newInstance.getAnimal().getId());
         }
 
         Medico medico = medicoServiceInterface.findByUserId(sessionId);
@@ -1750,13 +1779,13 @@ public class Facade {
             throw new IllegalArgumentException("FichaRequest não pode ser nulo.");
         }
 
-        if (obj.getAgendamento() == null) {
-            throw new IllegalArgumentException("Ficha deve estar vinculada a um agendamento.");
+        if (obj.getAnimal() == null) {
+            throw new IllegalArgumentException("Ficha deve estar vinculada a um animal.");
         }
 
-        Long agendamentoId = obj.getAgendamento().getId();
-        if (!agendamentoRepository.existsById(agendamentoId)) {
-            throw new ResourceNotFoundException("Agendamento", "id", agendamentoId);
+        Long animalId = obj.getAnimal().getId();
+        if (!animalRepository.existsById(animalId)) {
+            throw new ResourceNotFoundException("Animal", "id", animalId);
         }
 
         Ficha existingFicha = findFichaById(id);

--- a/back/src/main/java/br/edu/ufape/hvu/model/Animal.java
+++ b/back/src/main/java/br/edu/ufape/hvu/model/Animal.java
@@ -2,6 +2,7 @@ package br.edu.ufape.hvu.model;
 
 import java.time.LocalDate;
 import br.edu.ufape.hvu.model.enums.OrigemAnimal;
+import br.edu.ufape.hvu.model.enums.TipoAnimal;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -36,4 +37,9 @@ public class Animal  {
 	private OrigemAnimal origemAnimal;
 
 	private boolean obito;
+
+	private String codigoProntuario;
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private TipoAnimal tipo;
 }

--- a/back/src/main/java/br/edu/ufape/hvu/model/ContadorProntuario.java
+++ b/back/src/main/java/br/edu/ufape/hvu/model/ContadorProntuario.java
@@ -1,0 +1,24 @@
+package br.edu.ufape.hvu.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "contador_prontuario")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class ContadorProntuario {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private long id;
+
+    @Column(nullable = false)
+    private int ultimoValor;
+
+    @Column(nullable = false)
+    private boolean valorInicialConfigurado;
+}

--- a/back/src/main/java/br/edu/ufape/hvu/model/Ficha.java
+++ b/back/src/main/java/br/edu/ufape/hvu/model/Ficha.java
@@ -31,4 +31,7 @@ public class Ficha {
     @ManyToOne
     @JoinColumn(name = "medico_id")
     private Medico medico;
+    @ManyToOne
+    @JoinColumn(name = "animal_id")
+    private Animal animal;
 }

--- a/back/src/main/java/br/edu/ufape/hvu/model/enums/TipoAnimal.java
+++ b/back/src/main/java/br/edu/ufape/hvu/model/enums/TipoAnimal.java
@@ -1,0 +1,6 @@
+package br.edu.ufape.hvu.model.enums;
+
+public enum TipoAnimal {
+    COMUM,
+    SILVESTRE
+}

--- a/back/src/main/java/br/edu/ufape/hvu/repository/AgendamentoRepository.java
+++ b/back/src/main/java/br/edu/ufape/hvu/repository/AgendamentoRepository.java
@@ -6,16 +6,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
 import br.edu.ufape.hvu.model.Agendamento;
 import br.edu.ufape.hvu.model.Animal;
 
 @Repository
 public interface AgendamentoRepository extends JpaRepository<Agendamento, Long> {
-
-	
 	@Query("SELECT v.agendamento FROM Vaga v WHERE v.medico.id = :medicoId AND v.agendamento IS NOT NULL")
     List<Agendamento> findAgendamentosByMedicoId(@Param("medicoId") Long medicoId);
 	
 	List<Agendamento> findByAnimal( Animal animal);
+
+	boolean existsByAnimalId(Long animalId);
 }

--- a/back/src/main/java/br/edu/ufape/hvu/repository/ContadorProntuarioRepository.java
+++ b/back/src/main/java/br/edu/ufape/hvu/repository/ContadorProntuarioRepository.java
@@ -1,0 +1,9 @@
+package br.edu.ufape.hvu.repository;
+
+import br.edu.ufape.hvu.model.ContadorProntuario;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContadorProntuarioRepository extends JpaRepository<ContadorProntuario, Long> {
+}

--- a/back/src/main/java/br/edu/ufape/hvu/repository/FichaRepository.java
+++ b/back/src/main/java/br/edu/ufape/hvu/repository/FichaRepository.java
@@ -7,9 +7,8 @@ import java.util.List;
 
 @Repository
 public interface FichaRepository extends JpaRepository<Ficha, Long> {
-
     List<Ficha> findByAgendamentoId(Long agendamentoId);
     List<Ficha> findByMedicoId(Long medicoId);
     List<Ficha> findByAnimalId(Long animalId);
-
+    boolean existsByAnimalId(Long animalId);
 }

--- a/back/src/main/java/br/edu/ufape/hvu/repository/FichaRepository.java
+++ b/back/src/main/java/br/edu/ufape/hvu/repository/FichaRepository.java
@@ -10,6 +10,6 @@ public interface FichaRepository extends JpaRepository<Ficha, Long> {
 
     List<Ficha> findByAgendamentoId(Long agendamentoId);
     List<Ficha> findByMedicoId(Long medicoId);
-    List<Ficha> findByAgendamentoAnimalId(Long animalId);
+    List<Ficha> findByAnimalId(Long animalId);
 
 }

--- a/back/src/main/java/br/edu/ufape/hvu/repository/seeders/AnimalSeeder.java
+++ b/back/src/main/java/br/edu/ufape/hvu/repository/seeders/AnimalSeeder.java
@@ -3,6 +3,7 @@ package br.edu.ufape.hvu.repository.seeders;
 import br.edu.ufape.hvu.model.Animal;
 import br.edu.ufape.hvu.model.Raca;
 import br.edu.ufape.hvu.model.enums.OrigemAnimal;
+import br.edu.ufape.hvu.model.enums.TipoAnimal;
 import br.edu.ufape.hvu.repository.AnimalRepository;
 import br.edu.ufape.hvu.repository.RacaRepository;
 import com.github.javafaker.Faker;
@@ -34,6 +35,7 @@ public class AnimalSeeder {
             animal.setNumeroFicha(faker.idNumber().valid());
             animal.setRaca(racas.get(0));
             animal.setOrigemAnimal(OrigemAnimal.HVU);
+            animal.setTipo(TipoAnimal.COMUM);
             animalRepository.save(animal);
         }
     }

--- a/back/src/main/java/br/edu/ufape/hvu/repository/seeders/FichaSeeder.java
+++ b/back/src/main/java/br/edu/ufape/hvu/repository/seeders/FichaSeeder.java
@@ -66,6 +66,7 @@ public class FichaSeeder {
 
             Agendamento agendamentoAleatorio = agendamentos.get(faker.random().nextInt(agendamentos.size()));
             ficha.setAgendamento(agendamentoAleatorio);
+            ficha.setAnimal(agendamentoAleatorio.getAnimal());
 
             Medico medicoAleatorio = medicos.get(faker.random().nextInt(medicos.size()));
             ficha.setMedico(medicoAleatorio);

--- a/back/src/main/java/br/edu/ufape/hvu/service/CodigoProntuarioService.java
+++ b/back/src/main/java/br/edu/ufape/hvu/service/CodigoProntuarioService.java
@@ -1,0 +1,98 @@
+package br.edu.ufape.hvu.service;
+
+import br.edu.ufape.hvu.model.Animal;
+import br.edu.ufape.hvu.model.ContadorProntuario;
+import br.edu.ufape.hvu.model.enums.TipoAnimal;
+import br.edu.ufape.hvu.repository.ContadorProntuarioRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CodigoProntuarioService {
+
+    private final ContadorProntuarioRepository contadorProntuarioRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Transactional
+    public String garantirCodigoProntuario(long animalId) {
+
+        Animal animal = entityManager.find(
+                Animal.class,
+                animalId,
+                LockModeType.PESSIMISTIC_WRITE);
+
+        if (animal == null) {
+            throw new IllegalArgumentException(
+                    "Animal não encontrado com id " + animalId);
+        }
+
+        if (animal.getCodigoProntuario() != null &&
+                !animal.getCodigoProntuario().isBlank()) {
+            return animal.getCodigoProntuario();
+        }
+
+        String codigo = proximoCodigo(animal.getTipo());
+
+        animal.setCodigoProntuario(codigo);
+
+        return codigo;
+    }
+
+    @Transactional
+    public ContadorProntuario definirValorInicial(int valorInicial) {
+
+        if (valorInicial < 1) {
+            throw new IllegalArgumentException(
+                    "Valor inicial deve ser maior ou igual a 1.");
+        }
+
+        ContadorProntuario contador = buscarContadorComLock();
+
+        if (contador.isValorInicialConfigurado()) {
+            throw new IllegalArgumentException(
+                    "O valor inicial já foi configurado.");
+        }
+
+        if (contador.getUltimoValor() > 0) {
+            throw new IllegalArgumentException(
+                    "Já existem códigos de prontuário gerados.");
+        }
+
+        contador.setUltimoValor(valorInicial - 1);
+        contador.setValorInicialConfigurado(true);
+
+        return contadorProntuarioRepository.save(contador);
+    }
+
+    private String proximoCodigo(TipoAnimal tipo) {
+
+        ContadorProntuario contador = buscarContadorComLock();
+
+        contador.setUltimoValor(contador.getUltimoValor() + 1);
+        contadorProntuarioRepository.save(contador);
+
+        return switch (tipo) {
+            case COMUM ->
+                    String.format("%03d", contador.getUltimoValor());
+
+            case SILVESTRE ->
+                    String.format("%03dSIL", contador.getUltimoValor());
+        };
+    }
+
+    private ContadorProntuario buscarContadorComLock() {
+
+        return entityManager.createQuery(
+                        "SELECT c FROM ContadorProntuario c",
+                        ContadorProntuario.class)
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                .getSingleResult();
+    }
+}

--- a/back/src/main/java/br/edu/ufape/hvu/service/FichaService.java
+++ b/back/src/main/java/br/edu/ufape/hvu/service/FichaService.java
@@ -37,7 +37,7 @@ public class FichaService implements FichaServiceInterface {
     }
 
     public List<Ficha> findFichasByAnimalId(long animalId) {
-        return repository.findByAgendamentoAnimalId(animalId);
+        return repository.findByAnimalId(animalId);
     }
 
     public List<Ficha> getAllFicha(){

--- a/back/src/main/java/br/edu/ufape/hvu/service/FichaService.java
+++ b/back/src/main/java/br/edu/ufape/hvu/service/FichaService.java
@@ -36,6 +36,10 @@ public class FichaService implements FichaServiceInterface {
         return repository.findByMedicoId(medicoId);
     }
 
+    public boolean existsByAnimalId(long id) {
+        return repository.existsByAnimalId(id);
+    }
+
     public List<Ficha> findFichasByAnimalId(long animalId) {
         return repository.findByAnimalId(animalId);
     }

--- a/back/src/main/java/br/edu/ufape/hvu/service/FichaServiceInterface.java
+++ b/back/src/main/java/br/edu/ufape/hvu/service/FichaServiceInterface.java
@@ -7,6 +7,7 @@ import java.util.List;
 public interface FichaServiceInterface {
     Ficha saveFicha(Ficha o);
     Ficha findFichaById(long id);
+    boolean existsByAnimalId(long id);
     List<Ficha> findFichasByAgendamentoId(long agendamentoId);
     List<Ficha> findFichasByMedicoId(long medicoId);
     List<Ficha> findFichasByAnimalId(long animalId);

--- a/back/src/main/resources/db/migration/V29__adicionar_codigo_prontuario_e_tipo_animal_em_animal.sql.sql
+++ b/back/src/main/resources/db/migration/V29__adicionar_codigo_prontuario_e_tipo_animal_em_animal.sql.sql
@@ -1,0 +1,10 @@
+ALTER TABLE animal
+    ADD COLUMN codigo_prontuario VARCHAR(20),
+    ADD COLUMN tipo VARCHAR(20) NOT NULL DEFAULT 'COMUM';
+
+ALTER TABLE animal
+    ADD CONSTRAINT uk_animal_codigo_prontuario UNIQUE (codigo_prontuario);
+
+ALTER TABLE animal
+    ADD CONSTRAINT animal_tipo_check
+        CHECK (tipo IN ('COMUM', 'SILVESTRE'));

--- a/back/src/main/resources/db/migration/V30__adicionar_atributo_animal_a_ficha.sql
+++ b/back/src/main/resources/db/migration/V30__adicionar_atributo_animal_a_ficha.sql
@@ -1,0 +1,7 @@
+ALTER TABLE ficha
+ADD COLUMN animal_id BIGINT;
+
+ALTER TABLE ficha
+ADD CONSTRAINT fk_ficha_animal
+FOREIGN KEY (animal_id)
+REFERENCES animal(id);

--- a/back/src/main/resources/db/migration/V31__adicionar_tabela_contador_prontuario.sql
+++ b/back/src/main/resources/db/migration/V31__adicionar_tabela_contador_prontuario.sql
@@ -1,0 +1,8 @@
+CREATE TABLE contador_prontuario (
+    id BIGSERIAL PRIMARY KEY,
+    ultimo_valor INTEGER NOT NULL DEFAULT 0,
+    valor_inicial_configurado BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+INSERT INTO contador_prontuario (ultimo_valor, valor_inicial_configurado)
+VALUES (0, FALSE);


### PR DESCRIPTION
- Adiciona novo atributo `Animal animal;` na entidade `Ficha`, para ser o novo principal relacionamento
    - Remove obrigatoriedade de agendamento no CRUD de fichas e agora passa a requisitar obrigatoriedade de animal
    - Cria migration para essa nova alteração, altera DTO e seeders

- Implementa novo atributo `String codigoProntuário;` na entidade `Animal`
  - Cria migration para adicionar essa nova coluna ao banco, altera DTO de response de animal para o novo atributo
  
- Implementa novo atributo (enum) ` TipoAnimal tipo;` na entidade `Animal`
   - Cria enum TipoAnimal com os valores `COMUM` e `SILVESTRE` para controlar o `codigoProntuario`
   - Altera métodos de Crud e conversão de entidade de animal para setar o novo atributo como `COMUM` caso não seja enviado
   - Cria migration para setar tipos aceitáveis, altera DTO e também seeders
   
- Implementa model, repository e service `ContadorProntuario, CodigoProntuarioRepository, CodigoProntuarioService`
    - O código é gerado somente para animais que estão fazendo seu primeiro agendamento
    - Não é gerado para animais que já tiveram ao menos um agendamento (pois já possuem código de prontuário existente nos documentos do HVU)
    - Usar o mesmo código de prontuário em todas as N fichas daquele animal (o atributo pertence a animal, logo, toda ficha daquele animal terá o mesmo código)
    - Para animais do tipo COMUM, segue o formato 001, 002...
    - Para animais silvestres, segue o formato 001SIL, 002SIL, mas ambos compartilham o mesmo contador
    
- Inclui um novo endpoint `animal/prontuario/valor-inicial` que será acessado por secretário para adicionar o valor personalizado que irá iniciar a contagem de prontuários, pois o HVU já tem esse número em andamento
    - Só pode ser utilizado uma única vez

